### PR TITLE
fit added tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13269,6 +13269,22 @@
         "react-transition-group": "^4.4.1"
       }
     },
+    "react-tooltip": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.10.tgz",
+      "integrity": "sha512-D7ZLx6/QwpUl0SZRek3IZy/HWpsEEp0v3562tcT8IwZgu8IgV7hY5ZzniTkHyRcuL+IQnljpjj7A7zCgl2+T3w==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-scripts": "4.0.0",
     "react-toast-notifications": "^2.4.0",
     "react-toastify": "^6.1.0",
+    "react-tooltip": "^4.2.10",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,6 @@
 import React, {Component} from 'react';
+import ReactTooltip from 'react-tooltip';
+
 import '../styles/footer.css';
 import checkLogo from '../assets/images/check-icon.png';
 import {Link} from 'react-router-dom';
@@ -16,14 +18,17 @@ export default function Footer(propos) {
                               toDO
                            </li>
                            <li title="Go to Home">
-                              <Link to="/">{propos.page}</Link> 
+                              <Link to="/" data-tip="Go Home">{propos.page}</Link> 
                            </li>
                        </ul>
                     </div>
                     <div className="right-wrapper">
                          <ul>
                              <li>
-                               Copyright 2020, <a href="https://patrickniyo.netlify.app" target="_blank">PatrickNiyo</a>
+                               Copyright 2020, 
+                               <a href="https://patrickniyo.netlify.app" target="_blank" data-tip="Visit Developer's official website">PatrickNiyo</a>
+                               <ReactTooltip place="left" type="info" effect="solid"/>
+
                             </li>
                          </ul>
                     </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import {Link} from 'react-router-dom'
+import ReactTooltip from 'react-tooltip';
 import '../styles/home.css';
 import imageURL from '../assets/images/home-img.svg';
 import Footer from '../components/Footer';
@@ -81,8 +82,10 @@ class Home extends Component {
                             </span>
                         </small>
                         </h1>
-                   
-                   <Link to='/login'> <button> Get Started</button></Link> 
+                  
+                 
+                   <Link to='/login'> <button data-tip="You need to login to access you board!"> Get Started</button></Link> 
+                   <ReactTooltip place="left" type="info" effect="solid"/>
                 </div>
                 <div className="rightWrapper">
                    <img src={imageURL} alt="image"/>


### PR DESCRIPTION
### **What does this PR do**
It added tooltips

### **Feature description**
When `Get started` button is hovered the tooltip guiding is shown

### **How to manually test this**
- Clone the repository.
- Use `npm install` to install used modules.
- Use `npm start` to start the server
- Hover on `Get started` button

### **Expected outputs**
- A tooltip should be displayed with data tips

### **Screenshot**
![Screenshot from 2020-11-13 11-08-36](https://user-images.githubusercontent.com/54368821/99039421-fff92080-258f-11eb-9db9-b888eb18e2d7.png)
![Screenshot from 2020-11-13 11-09-05](https://user-images.githubusercontent.com/54368821/99039452-0b4c4c00-2590-11eb-9b57-6c6cbf1fcaf4.png)

